### PR TITLE
fix(a11y): increase touch target size for phone links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -132,15 +132,15 @@ const currentYear = new Date().getFullYear();
                 <h4 class="font-serif text-lg mb-6 text-white">Contact</h4>
                 <address class="not-italic text-sm text-white/70 space-y-3">
                     <p>Laageinde 11, 4191 NR Geldermalsen</p>
-                    <p>
+                    <p class="flex flex-col gap-1">
                         <a
                             href="tel:+31345616182"
-                            class="hover:text-white transition-colors block"
+                            class="hover:text-white transition-colors block min-h-12 py-2 flex items-center"
                             >0345 - 616 182</a
                         >
                         <a
                             href="tel:+31623070327"
-                            class="hover:text-white transition-colors block"
+                            class="hover:text-white transition-colors block min-h-12 py-2 flex items-center"
                             >06 - 23 07 03 27</a
                         >
                     </p>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -36,15 +36,15 @@ import Layout from "../layouts/Layout.astro";
                             <h3 class="font-serif text-xl text-primary mb-2">
                                 Telefoon
                             </h3>
-                            <p class="text-text-muted">
+                            <p class="text-text-muted flex flex-col gap-1">
                                 <a
                                     href="tel:+31345616182"
-                                    class="hover:text-primary transition-colors block"
+                                    class="hover:text-primary transition-colors block min-h-12 py-2 flex items-center"
                                     >0345 - 616 182</a
                                 >
                                 <a
                                     href="tel:+31623070327"
-                                    class="hover:text-primary transition-colors block"
+                                    class="hover:text-primary transition-colors block min-h-12 py-2 flex items-center"
                                     >06 - 23 07 03 27</a
                                 >
                             </p>


### PR DESCRIPTION
## Summary
- Add minimum 48px height (`min-h-12`) to phone links in footer and contact page
- Add proper spacing between adjacent touch targets with `gap-1`
- Ensures WCAG-compliant touch target sizing for mobile accessibility

## Test plan
- [ ] Verify phone links in footer have adequate touch target size on mobile
- [ ] Verify phone links on contact page have adequate touch target size on mobile
- [ ] Run PageSpeed Insights to confirm issue is resolved

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)