### PR TITLE
fix: anchor scroll to contact form and mobile UX improvements

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -41,7 +41,7 @@ import heroImage from "../assets/images/hero-interior.webp";
 
                     <div class="flex flex-col sm:flex-row gap-4">
                         <a
-                            href="/contact"
+                            href="/contact#form"
                             class="inline-flex justify-center items-center px-8 py-4 border border-transparent text-sm font-medium rounded-sm shadow-sm text-white bg-primary hover:bg-primary-light transition-all duration-300 transform hover:-translate-y-0.5"
                         >
                             Plan uw project

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -49,7 +49,7 @@ import { Image } from "astro:assets";
 
                 <!-- CTA -->
                 <a
-                    href="/contact"
+                    href="/contact#form"
                     class="inline-flex items-center justify-center px-6 py-2.5 border border-primary/10 text-sm font-medium rounded-sm text-white bg-primary hover:bg-primary-light transition-all duration-300 shadow-sm hover:shadow-md"
                 >
                     Vrijblijvend advies
@@ -109,7 +109,7 @@ import { Image } from "astro:assets";
             >Portfolio</a
         >
         <a
-            href="/contact"
+            href="/contact#form"
             class="inline-flex items-center justify-center px-8 py-3 border border-primary/10 text-base font-medium rounded-sm text-white bg-primary hover:bg-primary-light transition-all duration-300 shadow-sm hover:shadow-md"
         >
             Vrijblijvend advies

--- a/src/components/ProjectGallery.tsx
+++ b/src/components/ProjectGallery.tsx
@@ -73,9 +73,10 @@ export default function ProjectGallery({ projects }: ProjectGalleryProps) {
                                 <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-colors duration-500" />
 
                                 <div className="absolute inset-0 p-8 flex flex-col justify-end">
-                                    <div className="translate-y-4 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-500">
-                                        <span className="text-xs uppercase tracking-wider text-accent mb-1 block">
-                                            {project.category}
+                                    <div className="translate-y-0 md:translate-y-4 opacity-100 md:opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-500">
+                                        <span className="relative inline-block text-xs uppercase tracking-wider text-white mb-2">
+                                            <span className="absolute inset-0 bg-accent -skew-x-6 -rotate-1 scale-x-110 scale-y-125 rounded-sm"></span>
+                                            <span className="relative px-2 py-0.5">{project.category}</span>
                                         </span>
                                         <h3 className="text-white font-serif text-2xl">
                                             {project.title}

--- a/src/components/ServiceShowcase.astro
+++ b/src/components/ServiceShowcase.astro
@@ -40,10 +40,10 @@ const services = allServices.slice(0, 4).map(service => ({
             <!-- Content -->
             <div class="absolute bottom-0 left-0 p-8 md:p-12 w-full transform transition-transform duration-500 group-hover:-translate-y-2">
                 <h3 class="text-2xl md:text-3xl font-serif text-white mb-3 border-l-4 border-accent pl-4 group-hover:border-white transition-colors">{service.title}</h3>
-                <p class="text-white/80 max-w-md pl-4 opacity-0 transform translate-y-4 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-500 delay-100 ease-out text-lg">
+                <p class="text-white/80 max-w-md pl-4 hidden md:block opacity-0 transform translate-y-4 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-500 delay-100 ease-out text-lg">
                 {service.description}
                 </p>
-                <div class="mt-6 pl-4 opacity-0 group-hover:opacity-100 transition-opacity duration-500 delay-200">
+                <div class="mt-6 pl-4 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity duration-500 delay-200">
                 <span class="text-white text-sm font-medium border-b border-accent pb-1 inline-flex items-center gap-2">
                     Bekijk expertise 
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -73,9 +73,10 @@ export const ProjectCard = ({
                 <div className="absolute inset-0 bg-black/20 group-hover:bg-black/40 transition-colors duration-500" />
 
                 {/* Text content */}
-                <div className="absolute bottom-6 left-6 text-white translate-y-4 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-500">
-                    <span className="text-xs uppercase tracking-wider text-accent mb-1 block">
-                        {category}
+                <div className="absolute bottom-6 left-6 text-white translate-y-0 md:translate-y-4 opacity-100 md:opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-500">
+                    <span className="relative inline-block text-xs uppercase tracking-wider text-white mb-2">
+                        <span className="absolute inset-0 bg-accent -skew-x-6 -rotate-1 scale-x-110 scale-y-125 rounded-sm"></span>
+                        <span className="relative px-2 py-0.5">{category}</span>
                     </span>
                     <h3 className="text-2xl font-serif text-white">{title}</h3>
                 </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -38,7 +38,7 @@ export const projects: Project[] = [
             "/images/photo-1523413651479-597eb2da0ad6.webp", // Brick/Window detail
             "/images/photo-1595853035070-59a39fe84de3.webp" // Wood detail
         ],
-        size: "col-span-2 row-span-2",
+        size: "md:col-span-2 md:row-span-2",
     },
     {
         title: "Detail Lakwerk Entree",
@@ -59,7 +59,7 @@ export const projects: Project[] = [
             "/images/photo-1617806118233-18e1de247200.webp", // Clean wall/door
             "/images/photo-1560448204-e02f11c3d0e2.webp" // Staircase detail
         ],
-        size: "col-span-1 row-span-1",
+        size: "md:col-span-1 md:row-span-1",
     },
     {
         title: "Villa Tiel",
@@ -80,7 +80,7 @@ export const projects: Project[] = [
             "/images/photo-1600607687939-ce8a6c25118c.webp", // Modern villa detail
             "/images/photo-1598928506311-c55ded91a20c.webp" // Modern exterior
         ],
-        size: "col-span-1 row-span-1",
+        size: "md:col-span-1 md:row-span-1",
     },
     {
         title: "Marmerstuc Badkamer",
@@ -101,7 +101,7 @@ export const projects: Project[] = [
             "/images/photo-1631679706909-1844bbd07221.webp", // Modern Bath
             "/images/photo-1560185893-a55cbc8c57e8.webp" // Texture
         ],
-        size: "col-span-1 row-span-2",
+        size: "md:col-span-1 md:row-span-2",
     },
     {
         title: "Herenhuis Culemborg",
@@ -120,7 +120,7 @@ export const projects: Project[] = [
             "/images/photo-1615529182904-14819c35db37.webp", // Living room
             "/images/photo-1595853035070-59a39fe84de3.webp" // Detail
         ],
-        size: "col-span-1 row-span-1 lg:col-span-2",
+        size: "md:col-span-1 md:row-span-1 lg:col-span-2",
     },
     {
         title: "Monumentaal Plafond",
@@ -139,6 +139,6 @@ export const projects: Project[] = [
             "/images/photo-1562663474-6cbb3eaa4d14.webp", // Ceiling detail
             "/images/photo-1560185008-b033106af5c3.webp" // Classic interior
         ],
-        size: "col-span-2 row-span-1",
+        size: "md:col-span-2 md:row-span-1",
     },
 ];

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -65,7 +65,7 @@ import Layout from "../layouts/Layout.astro";
                 </div>
 
                 <!-- Form (Consultative) -->
-                <div class="bg-white p-8 lg:p-12 rounded-sm shadow-xl">
+                <div id="form" class="bg-white p-8 lg:p-12 rounded-sm shadow-xl scroll-mt-24">
                     <h3 class="font-serif text-2xl text-primary mb-6">
                         Aanvraag Adviesgesprek
                     </h3>

--- a/src/pages/diensten/[slug].astro
+++ b/src/pages/diensten/[slug].astro
@@ -119,7 +119,7 @@ const { service } = Astro.props;
                                     Wij schilderen voor de lange termijn.
                                 </p>
                                 <a
-                                    href="/contact"
+                                    href="/contact#form"
                                     class="inline-flex items-center text-primary font-medium hover:text-accent transition-colors group"
                                 >
                                     Plan een vrijblijvend adviesgesprek
@@ -152,7 +152,7 @@ const { service } = Astro.props;
                     Klaar voor de volgende stap?
                 </h2>
                 <a
-                    href="/contact"
+                    href="/contact#form"
                     class="inline-flex justify-center items-center px-8 py-4 bg-primary text-white text-sm font-medium rounded-sm hover:bg-primary-light transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
                 >
                     Vraag een offerte aan voor {service.title.toLowerCase()}

--- a/src/pages/over-ons.astro
+++ b/src/pages/over-ons.astro
@@ -25,18 +25,20 @@ import Layout from "../layouts/Layout.astro";
     <section class="py-24 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex flex-col md:flex-row gap-16 items-start">
-                <div class="w-full md:w-1/2 prose prose-lg text-text-muted">
+                <div class="w-full md:w-1/2 prose prose-lg text-text-muted space-y-6">
                     <h2 class="font-serif text-3xl text-primary mb-6">
                         Niet de grootste, wel de beste.
                     </h2>
                     <p>
                         Toen ik begon met Schildersbedrijf Visser, had ik één
                         doel: schilderwerk leveren waar ik zelf trots op zou
-                        zijn als het mijn eigen huis was. In de afgelopen
-                        decennia heb ik de schilderswereld zien veranderen.
-                        Alles moet sneller, goedkoper, efficiënter.
+                        zijn als het mijn eigen huis was.
                     </p>
-                    <p>Ik heb besloten daaraan niet mee te doen.</p>
+                    <p>
+                        In de afgelopen decennia heb ik de schilderswereld zien
+                        veranderen. Alles moet sneller, goedkoper, efficiënter.
+                        Ik heb besloten daaraan niet mee te doen.
+                    </p>
                     <p>
                         Bij Schildersbedrijf Visser nemen we de tijd. Tijd om de
                         ondergrond écht goed te inspecteren. Tijd om te schuren

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -34,7 +34,7 @@ import { projects } from "../data/projects";
                     Benieuwd wat we voor uw woning kunnen betekenen?
                 </p>
                 <a
-                    href="/contact"
+                    href="/contact#form"
                     class="inline-flex items-center px-8 py-4 border border-primary/10 text-sm font-medium rounded-sm text-white bg-primary hover:bg-primary-light transition-all shadow-lg"
                 >
                     Plan een vrijblijvend gesprek


### PR DESCRIPTION
## Summary
- Add `#form` anchor to contact page with proper scroll-margin-top for fixed navbar
- Update all CTA buttons (Hero, Navbar, Diensten, Portfolio) to link to `/contact#form`
- Make project card category/title visible on mobile without hover
- Add paint stroke effect behind category labels for better readability
- Fix inconsistent project card sizes on mobile (uniform sizing)
- Hide service description on mobile in expertise section, keep CTA visible
- Add paragraph spacing to over-ons page text

## Test plan
- [ ] Click any "Vrijblijvend advies" or CTA button - should scroll to contact form
- [ ] Check project cards on mobile - text should be visible without tap
- [ ] Check portfolio page on mobile - same behavior
- [ ] Check over-ons page - paragraphs should have visible spacing

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)