### PR TITLE
fix: add noindex meta tag to prevent search engine indexing 🐛

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -34,6 +34,7 @@ const heroTablet = isHomepage
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/webp" href="/favicon.webp" />
 		<meta name="generator" content={Astro.generator} />
+		<meta name="robots" content="noindex, nofollow" />
 		<title>{title}</title>
 		{
 			isHomepage && heroMobile && heroTablet && (


### PR DESCRIPTION
## Summary
- Added `<meta name="robots" content="noindex, nofollow" />` to the `<head>` in `Layout.astro`
- Combined with existing `robots.txt` (`Disallow: /`), this fully prevents the demo site from appearing in search results

## Test plan
- [ ] Verify the meta tag appears in the `<head>` of all pages
- [ ] Confirm `robots.txt` still blocks crawling

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)